### PR TITLE
Fixed typo in python example code

### DIFF
--- a/draft.txt
+++ b/draft.txt
@@ -5,9 +5,9 @@
 Network Working Group                                           E. Kline
 Internet-Draft                                              Google Japan
 Intended status: Experimental                                  K. Duleba
-Expires: January 29, 2015                                    Z. Szamonek
+Expires: July 14, 2016                                       Z. Szamonek
                                                  Google Switzerland GmbH
-                                                           July 28, 2014
+                                                        January 11, 2016
 
 
             A Format for Self-published IP Geolocation Feeds
@@ -35,10 +35,10 @@ Abstract
    multiple regions from London: - add use case for more granularity (?)
    - include ISP privacy info URL - User can discover if they're in a
    feed, increases transparency - RIPE whois field, RDAP - create link
-   relationship, RFC 5988 References: - opengeofeed.org - https://
-   www.opengeofeed.org/feed/public.csv - Mozilla Location Service https:
-   //location.services.mozilla.com/ - https://bugzilla.mozilla.org/
-   show_bug.cgi?id=1042925
+   relationship, RFC 5988 References: - opengeofeed.org -
+   https://www.opengeofeed.org/feed/public.csv - Mozilla Location
+   Service https://location.services.mozilla.com/ -
+   https://bugzilla.mozilla.org/show_bug.cgi?id=1042925
 
 Status of This Memo
 
@@ -53,9 +53,9 @@ Status of This Memo
 
 
 
-Kline, et al.           Expires January 29, 2015                [Page 1]
+Kline, et al.             Expires July 14, 2016                 [Page 1]
 
-Internet-Draft         Self-published IP Geofeeds              July 2014
+Internet-Draft         Self-published IP Geofeeds           January 2016
 
 
    Internet-Drafts are draft documents valid for a maximum of six months
@@ -63,11 +63,11 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 29, 2015.
+   This Internet-Draft will expire on July 14, 2016.
 
 Copyright Notice
 
-   Copyright (c) 2014 IETF Trust and the persons identified as the
+   Copyright (c) 2016 IETF Trust and the persons identified as the
    document authors.  All rights reserved.
 
    This document is subject to BCP 78 and the IETF Trust's Legal
@@ -88,7 +88,7 @@ Table of Contents
 
    1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
      1.1.  Motivation  . . . . . . . . . . . . . . . . . . . . . . .   3
-     1.2.  Requirements notation . . . . . . . . . . . . . . . . . .   3
+     1.2.  Requirements notation . . . . . . . . . . . . . . . . . .   4
      1.3.  Implications of publication . . . . . . . . . . . . . . .   4
    2.  Self-published IP geolocation feeds . . . . . . . . . . . . .   4
      2.1.  Specification . . . . . . . . . . . . . . . . . . . . . .   4
@@ -104,14 +104,14 @@ Table of Contents
      3.1.  Feed integrity  . . . . . . . . . . . . . . . . . . . . .   9
      3.2.  Verification of authority . . . . . . . . . . . . . . . .   9
      3.3.  Verification of accuracy  . . . . . . . . . . . . . . . .   9
-     3.4.  Refreshing feed information . . . . . . . . . . . . . . .  10
+     3.4.  Refreshing feed information . . . . . . . . . . . . . . .   9
    4.  Privacy Considerations  . . . . . . . . . . . . . . . . . . .  10
 
 
 
-Kline, et al.           Expires January 29, 2015                [Page 2]
+Kline, et al.             Expires July 14, 2016                 [Page 2]
 
-Internet-Draft         Self-published IP Geofeeds              July 2014
+Internet-Draft         Self-published IP Geofeeds           January 2016
 
 
    5.  Relation to other work  . . . . . . . . . . . . . . . . . . .  10
@@ -123,9 +123,10 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
    8.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  13
    9.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  14
      9.1.  Normative References  . . . . . . . . . . . . . . . . . .  14
-     9.2.  Informative References  . . . . . . . . . . . . . . . . .  14
+     9.2.  Informative References  . . . . . . . . . . . . . . . . .  15
+     9.3.  URIs  . . . . . . . . . . . . . . . . . . . . . . . . . .  16
    Appendix A.  Sample Python validation code  . . . . . . . . . . .  16
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  22
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  23
 
 1.  Introduction
 
@@ -158,17 +159,18 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
    small geolocation feeds.  At least one consumer (Google) has
    incorporated these ad hoc feeds into a geolocation data pipeline.
 
-1.2.  Requirements notation
 
 
 
 
 
 
-Kline, et al.           Expires January 29, 2015                [Page 3]
+Kline, et al.             Expires July 14, 2016                 [Page 3]
 
-Internet-Draft         Self-published IP Geofeeds              July 2014
+Internet-Draft         Self-published IP Geofeeds           January 2016
 
+
+1.2.  Requirements notation
 
    The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
@@ -219,11 +221,9 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
 
 
 
-
-
-Kline, et al.           Expires January 29, 2015                [Page 4]
+Kline, et al.             Expires July 14, 2016                 [Page 4]
 
-Internet-Draft         Self-published IP Geofeeds              July 2014
+Internet-Draft         Self-published IP Geofeeds           January 2016
 
 
    Feeds MUST use UTF-8 [RFC3629] character encoding.  Text after a '#'
@@ -233,7 +233,7 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
    Feeds MUST be in comma separated values format as described in
    [RFC4180].  Each feed entry is a text line of the form:
 
-    ip_prefix,country,region,city,postal_code
+       ip_prefix,country,region,city,postal_code
 
    The IP prefix field is REQUIRED, all others are OPTIONAL (can be
    empty), though the requisite minimum number of commas SHOULD be
@@ -277,9 +277,9 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
 
 
 
-Kline, et al.           Expires January 29, 2015                [Page 5]
+Kline, et al.             Expires July 14, 2016                 [Page 5]
 
-Internet-Draft         Self-published IP Geofeeds              July 2014
+Internet-Draft         Self-published IP Geofeeds           January 2016
 
 
    Examples include "Dublin", "New York", and "Sao Paulo" (specifically
@@ -306,9 +306,9 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
    fields which specify any degree of geolocation information.  For
    example:
 
-    127.0.0.0/8,,,,
-    224.0.0.0/4,,,,
-    240.0.0.0/4,,,,
+       127.0.0.0/8,,,,
+       224.0.0.0/4,,,,
+       240.0.0.0/4,,,,
 
    Historically, the user-assigned country identifier of "ZZ" had be
    used for this same purpose.  This is not necessarily preferred, and
@@ -333,9 +333,9 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
 
 
 
-Kline, et al.           Expires January 29, 2015                [Page 6]
+Kline, et al.             Expires July 14, 2016                 [Page 6]
 
-Internet-Draft         Self-published IP Geofeeds              July 2014
+Internet-Draft         Self-published IP Geofeeds           January 2016
 
 
    Feed entries with non-empty optional fields which fail to parse,
@@ -359,25 +359,25 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
    locations at country, region, city and postal code granularity level,
    respectively:
 
-    192.0.2.0/25,US,US-AL,,
-    192.0.2.5,US,US-AL,Alabaster,
-    192.0.2.128/25,PL,PL-MZ,,02-784
-    2001:db8::/32,PL,,,
-    2001:db8:cafe::/48,PL,PL-MZ,,02-784
+       192.0.2.0/25,US,US-AL,,
+       192.0.2.5,US,US-AL,Alabaster,
+       192.0.2.128/25,PL,PL-MZ,,02-784
+       2001:db8::/32,PL,,,
+       2001:db8:cafe::/48,PL,PL-MZ,,02-784
 
    Experimentally, RIPE has published geolocation information for their
    conference network prefixes, which change location in accordance with
    each new event.  [GEO_RIPE_NCC] at the time of writing contains:
 
-    193.0.24.0/21,IE,IE-D,Dublin,
-    2001:67c:64::/48,IE,IE-D,Dublin,
+       193.0.24.0/21,IE,IE-D,Dublin,
+       2001:67c:64::/48,IE,IE-D,Dublin,
 
    Similarly, ICANN has published geolocation information for their
    portable conference network prefixes.  [GEO_ICANN] at the time of
    writing contains:
 
-    199.91.192.0/21,US,US-CA,Los Angeles,
-    2620:f:8000::/48,US,US-CA,Los Angeles,
+       199.91.192.0/21,US,US-CA,Los Angeles,
+       2620:f:8000::/48,US,US-CA,Los Angeles,
 
    Furthermore, it is worth noting that the geolocation data of SixXS
    users, already available at whois.sixxs.net, is now also accessible
@@ -389,9 +389,9 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
 
 
 
-Kline, et al.           Expires January 29, 2015                [Page 7]
+Kline, et al.             Expires July 14, 2016                 [Page 7]
 
-Internet-Draft         Self-published IP Geofeeds              July 2014
+Internet-Draft         Self-published IP Geofeeds           January 2016
 
 
    o  the geolocation attributes of users with neighboring prefixes can
@@ -445,9 +445,9 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
 
 
 
-Kline, et al.           Expires January 29, 2015                [Page 8]
+Kline, et al.             Expires July 14, 2016                 [Page 8]
 
-Internet-Draft         Self-published IP Geofeeds              July 2014
+Internet-Draft         Self-published IP Geofeeds           January 2016
 
 
 3.  Consuming self-published IP geolocation feeds
@@ -493,24 +493,19 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
    Consumers SHOULD decide on discrepancy thresholds and SHOULD flag for
    administrative review feed entries which exceed set thresholds.
 
-
-
-
-
-
-
-
-
-Kline, et al.           Expires January 29, 2015                [Page 9]
-
-Internet-Draft         Self-published IP Geofeeds              July 2014
-
-
 3.4.  Refreshing feed information
 
    As a publisher can change geolocation data at any time and without
    notification consumers SHOULD implement mechanisms to periodically
    refresh local copies of feed data.  In the absence of any other
+
+
+
+Kline, et al.             Expires July 14, 2016                 [Page 9]
+
+Internet-Draft         Self-published IP Geofeeds           January 2016
+
+
    refresh timing information it is recommended that consumers SHOULD
    refresh feeds no less often than weekly.
 
@@ -549,41 +544,35 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
    format and for privacy.  The data elements in geolocation feeds are
    equivalent to the following XML structure (vis.  [RFC5139]):
 
-
-
-
-
-
-
-
-
-Kline, et al.           Expires January 29, 2015               [Page 10]
-
-Internet-Draft         Self-published IP Geofeeds              July 2014
-
-
-    <civicAddress>
-      <country>country</country>
-      <A1>region</A1>
-      <A2>city</A2>
-      <PC>postal_code</PC>
-    </civicAddress>
+       <civicAddress>
+         <country>country</country>
+         <A1>region</A1>
+         <A2>city</A2>
+         <PC>postal_code</PC>
+       </civicAddress>
 
    Providing geolocation information to this granularity is equivalent
    to the following privacy policy (vis. the definition of the
    'building' [8] level of disclosure):
 
-    <ruleset>
-      <rule>
-        <conditions/>
-        <actions/>
-        <transformations>
-          <provide-location profile="civic-transformation">
-            <provide-civic>building</provide-civic>
-          </provide-location>
-        </transformations>
-      </rule>
-    </ruleset>
+
+
+Kline, et al.             Expires July 14, 2016                [Page 10]
+
+Internet-Draft         Self-published IP Geofeeds           January 2016
+
+
+       <ruleset>
+         <rule>
+           <conditions/>
+           <actions/>
+           <transformations>
+             <provide-location profile="civic-transformation">
+               <provide-civic>building</provide-civic>
+             </provide-location>
+           </transformations>
+         </rule>
+       </ruleset>
 
 6.  Security Considerations
 
@@ -610,14 +599,6 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
 
 7.1.  Ad hoc 'well known' URIs
 
-
-
-
-Kline, et al.           Expires January 29, 2015               [Page 11]
-
-Internet-Draft         Self-published IP Geofeeds              July 2014
-
-
    To date, geolocation feeds have been shared informally in the form of
    HTTPS URIs exchanged in email threads.  The two example URIs
    documented above describe networks that change locations
@@ -628,6 +609,14 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
    including:
 
    o  personal knowledge of the parties involved in the exchange, and
+
+
+
+
+Kline, et al.             Expires July 14, 2016                [Page 11]
+
+Internet-Draft         Self-published IP Geofeeds           January 2016
+
 
    o  comparison of feed-advertised prefixes with the BGP-advertised
       prefixes of Autonomous System Numbers known to be operated by the
@@ -667,23 +656,24 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
    For example, assuming a purely theoretical service name of
    "x-geofeed", a 'reverse' DNS zone might contain a record of the form:
 
-
-
-Kline, et al.           Expires January 29, 2015               [Page 12]
-
-Internet-Draft         Self-published IP Geofeeds              July 2014
-
-
-    ;;       order pref flags
-    IN NAPTR 200   10   "u"    "x-geofeed"        ( ; service
-                                                    ; regexp
-                               "!.*!https://example.com/ipgeo.csv!"
-                               ""                   ; replacement
-                               )
+       ;;       order pref flags
+       IN NAPTR 200   10   "u"    "x-geofeed"        ( ; service
+                                                       ; regexp
+                                  "!.*!https://example.com/ipgeo.csv!"
+                                  ""                   ; replacement
+                                  )
 
    Attempts to locate the geolocation feed for a given IP address would
    begin by querying directly for a NAPTR record associated with the
    address's PTR-style name.  For example, 192.0.2.4 and 2001:db8::6
+
+
+
+Kline, et al.             Expires July 14, 2016                [Page 12]
+
+Internet-Draft         Self-published IP Geofeeds           January 2016
+
+
    would cause a NAPTR record request to be issued for "4.2.0.192.in-
    addr.arpa" and "6.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d
    .0.1.0.0.2.ip6.arpa", respectively.
@@ -722,128 +712,174 @@ Internet-Draft         Self-published IP Geofeeds              July 2014
 
 8.  Acknowledgements
 
-
-
-
-Kline, et al.           Expires January 29, 2015               [Page 13]
-
-Internet-Draft         Self-published IP Geofeeds              July 2014
-
-
    The authors would like to express their gratitude to reviewers and
    early implementers, including but not limited to Mikael Abrahamsson,
    Ray Bellis, John Bond, Alissa Cooper, Andras Erdei, Marco Hogewoning,
    Mike Joseph, Warren Kumari, Menno Schepers, Justyna Sidorska, Pim van
-   Pelt, and Bjoern A. Zeeb.  Richard L. Barnes in particular
+   Pelt, and Bjoern A.  Zeeb.  Richard L.  Barnes in particular
    contributed substantial review, text, and advice.
+
+
+
+
+
+
+
+Kline, et al.             Expires July 14, 2016                [Page 13]
+
+Internet-Draft         Self-published IP Geofeeds           January 2016
+
 
 9.  References
 
 9.1.  Normative References
 
    [ISO.3166.1alpha2]
-              International Organization for Standardization , "ISO
-              3166-1 decoding table", <http://www.iso.org/iso/home/
-              standards/country_codes/iso-3166-1_decoding_table.htm>.
+              International Organization for Standardization, "ISO
+              3166-1 decoding table",
+              <http://www.iso.org/iso/home/standards/country_codes/
+              iso-3166-1_decoding_table.htm>.
 
    [ISO.3166.2]
-              International Organization for Standardization , "ISO
+              International Organization for Standardization, "ISO
               3166-2:2007", <http://www.iso.org/iso/home/standards/
               country_codes.htm#2012_iso3166-2>.
 
    [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
-              Requirement Levels", BCP 14, RFC 2119, March 1997.
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <http://www.rfc-editor.org/info/rfc2119>.
 
    [RFC2616]  Fielding, R., Gettys, J., Mogul, J., Frystyk, H.,
               Masinter, L., Leach, P., and T. Berners-Lee, "Hypertext
-              Transfer Protocol -- HTTP/1.1", RFC 2616, June 1999.
+              Transfer Protocol -- HTTP/1.1", RFC 2616,
+              DOI 10.17487/RFC2616, June 1999,
+              <http://www.rfc-editor.org/info/rfc2616>.
 
    [RFC3629]  Yergeau, F., "UTF-8, a transformation format of ISO
-              10646", STD 63, RFC 3629, November 2003.
+              10646", STD 63, RFC 3629, DOI 10.17487/RFC3629, November
+              2003, <http://www.rfc-editor.org/info/rfc3629>.
 
    [RFC4180]  Shafranovich, Y., "Common Format and MIME Type for Comma-
-              Separated Values (CSV) Files", RFC 4180, October 2005.
+              Separated Values (CSV) Files", RFC 4180,
+              DOI 10.17487/RFC4180, October 2005,
+              <http://www.rfc-editor.org/info/rfc4180>.
 
    [RFC4291]  Hinden, R. and S. Deering, "IP Version 6 Addressing
-              Architecture", RFC 4291, February 2006.
+              Architecture", RFC 4291, DOI 10.17487/RFC4291, February
+              2006, <http://www.rfc-editor.org/info/rfc4291>.
 
    [RFC4632]  Fuller, V. and T. Li, "Classless Inter-domain Routing
               (CIDR): The Internet Address Assignment and Aggregation
-              Plan", BCP 122, RFC 4632, August 2006.
+              Plan", BCP 122, RFC 4632, DOI 10.17487/RFC4632, August
+              2006, <http://www.rfc-editor.org/info/rfc4632>.
+
+
+
+
+
+
+
+
+Kline, et al.             Expires July 14, 2016                [Page 14]
+
+Internet-Draft         Self-published IP Geofeeds           January 2016
+
 
 9.2.  Informative References
 
-   [GEOPRIV]  Internet Engineering Task Force , "IETF geopriv Working
-              Group", <http://datatracker.ietf.org/wg/geopriv/>.
-
    [GEO_ICANN]
-
-
-
-
-Kline, et al.           Expires January 29, 2015               [Page 14]
-
-Internet-Draft         Self-published IP Geofeeds              July 2014
-
-
-              Internet Corporation For Assigned Names and Numbers ,
-              "ICANN Meeting Geolocation Data", <https://
-              registration.icann.org/geo/google.csv>.
+              Internet Corporation For Assigned Names and Numbers,
+              "ICANN Meeting Geolocation Data",
+              <https://registration.icann.org/geo/google.csv>.
 
    [GEO_RIPE_NCC]
-              Schepers, M., "RIPE NCC Meeting Geolocation Data", <https:
-              //meetings.ripe.net/geo/google.csv>.
+              Schepers, M., "RIPE NCC Meeting Geolocation Data",
+              <https://meetings.ripe.net/geo/google.csv>.
 
    [GEO_SIXXS]
-              van Pelt, P., "SixXS Geolocation Data", <https://
-              www.sixxs.net/export/google/>.
+              van Pelt, P., "SixXS Geolocation Data",
+              <https://www.sixxs.net/export/google/>.
+
+   [GEOPRIV]  Internet Engineering Task Force, "IETF geopriv Working
+              Group", <http://datatracker.ietf.org/wg/geopriv/>.
 
    [IPADDR_PY]
               Shields, M. and P. Moody, "Python IP address manipulation
               library", <http://code.google.com/p/ipaddr-py/>.
 
-   [RFC2818]  Rescorla, E., "HTTP Over TLS", RFC 2818, May 2000.
+   [RFC2818]  Rescorla, E., "HTTP Over TLS", RFC 2818,
+              DOI 10.17487/RFC2818, May 2000,
+              <http://www.rfc-editor.org/info/rfc2818>.
 
    [RFC3053]  Durand, A., Fasano, P., Guardini, I., and D. Lento, "IPv6
-              Tunnel Broker", RFC 3053, January 2001.
+              Tunnel Broker", RFC 3053, DOI 10.17487/RFC3053, January
+              2001, <http://www.rfc-editor.org/info/rfc3053>.
 
    [RFC3403]  Mealling, M., "Dynamic Delegation Discovery System (DDDS)
-              Part Three: The Domain Name System (DNS) Database", RFC
-              3403, October 2002.
+              Part Three: The Domain Name System (DNS) Database",
+              RFC 3403, DOI 10.17487/RFC3403, October 2002,
+              <http://www.rfc-editor.org/info/rfc3403>.
 
    [RFC3912]  Daigle, L., "WHOIS Protocol Specification", RFC 3912,
-              September 2004.
+              DOI 10.17487/RFC3912, September 2004,
+              <http://www.rfc-editor.org/info/rfc3912>.
 
    [RFC4408]  Wong, M. and W. Schlitt, "Sender Policy Framework (SPF)
-              for Authorizing Use of Domains in E-Mail, Version 1", RFC
-              4408, April 2006.
+              for Authorizing Use of Domains in E-Mail, Version 1",
+              RFC 4408, DOI 10.17487/RFC4408, April 2006,
+              <http://www.rfc-editor.org/info/rfc4408>.
 
    [RFC4627]  Crockford, D., "The application/json Media Type for
-              JavaScript Object Notation (JSON)", RFC 4627, July 2006.
+              JavaScript Object Notation (JSON)", RFC 4627,
+              DOI 10.17487/RFC4627, July 2006,
+              <http://www.rfc-editor.org/info/rfc4627>.
+
+
+
+Kline, et al.             Expires July 14, 2016                [Page 15]
+
+Internet-Draft         Self-published IP Geofeeds           January 2016
+
 
    [RFC4848]  Daigle, L., "Domain-Based Application Service Location
               Using URIs and the Dynamic Delegation Discovery Service
-              (DDDS)", RFC 4848, April 2007.
+              (DDDS)", RFC 4848, DOI 10.17487/RFC4848, April 2007,
+              <http://www.rfc-editor.org/info/rfc4848>.
 
    [RFC5139]  Thomson, M. and J. Winterbottom, "Revised Civic Location
               Format for Presence Information Data Format Location
-              Object (PIDF-LO)", RFC 5139, February 2008.
+              Object (PIDF-LO)", RFC 5139, DOI 10.17487/RFC5139,
+              February 2008, <http://www.rfc-editor.org/info/rfc5139>.
 
    [RFC5952]  Kawamura, S. and M. Kawashima, "A Recommendation for IPv6
-              Address Text Representation", RFC 5952, August 2010.
+              Address Text Representation", RFC 5952,
+              DOI 10.17487/RFC5952, August 2010,
+              <http://www.rfc-editor.org/info/rfc5952>.
 
-   [RFC6772]  Schulzrinne, H., Tschofenig, H., Cuellar, J., Polk, J.,
-              Morris, J., and M. Thomson, "Geolocation Policy: A
+   [RFC6772]  Schulzrinne, H., Ed., Tschofenig, H., Ed., Cuellar, J.,
+              Polk, J., Morris, J., and M. Thomson, "Geolocation Policy:
+              A Document Format for Expressing Privacy Preferences for
+              Location Information", RFC 6772, DOI 10.17487/RFC6772,
+              January 2013, <http://www.rfc-editor.org/info/rfc6772>.
 
+9.3.  URIs
 
+   [1] http://tools.ietf.org/html/rfc4632#section-3.1
 
-Kline, et al.           Expires January 29, 2015               [Page 15]
-
-Internet-Draft         Self-published IP Geofeeds              July 2014
+   [2] http://tools.ietf.org/html/rfc4291#section-2.3
 
+   [3] http://tools.ietf.org/html/rfc2616#section-13.2
 
-              Document Format for Expressing Privacy Preferences for
-              Location Information", RFC 6772, January 2013.
+   [4] http://tools.ietf.org/html/rfc2616#section-14.21
+
+   [5] http://tools.ietf.org/html/rfc2616#section-14.9
+
+   [6] http://tools.ietf.org/html/rfc6772#section-13
+
+   [7] http://tools.ietf.org/html/rfc6772#section-13.5
+
+   [8] http://tools.ietf.org/html/rfc6772#section-6.5.1
 
 Appendix A.  Sample Python validation code
 
@@ -853,6 +889,15 @@ Appendix A.  Sample Python validation code
    basic validation.  It is intended for use by feed publishers before
    launching a feed.  Note that this validator does not verify the
    uniqueness of every IP prefix entry within the feed as a whole, but
+
+
+
+
+Kline, et al.             Expires July 14, 2016                [Page 16]
+
+Internet-Draft         Self-published IP Geofeeds           January 2016
+
+
    only verifies the syntax of each single line from within the feed.  A
    complete validator MUST also ensure IP prefix uniqueness.
 
@@ -860,341 +905,341 @@ Appendix A.  Sample Python validation code
    use of the open source ipaddr Python library for IP address and CIDR
    parsing and validation [IPADDR_PY].
 
-   #!/usr/bin/python
-   #
-   # Copyright (c) 2012 IETF Trust and the persons identified as authors of
-   # the code.  All rights reserved.  Redistribution and use in source and
-   # binary forms, with or without modification, is permitted pursuant to,
-   # and subject to the license terms contained in, the Simplified BSD
-   # License set forth in Section 4.c of the IETF Trust's Legal Provisions
-   # Relating to IETF Documents (http://trustee.ietf.org/license-info).
+#!/usr/bin/python
+#
+# Copyright (c) 2012 IETF Trust and the persons identified as authors of
+# the code.  All rights reserved.  Redistribution and use in source and
+# binary forms, with or without modification, is permitted pursuant to,
+# and subject to the license terms contained in, the Simplified BSD
+# License set forth in Section 4.c of the IETF Trust's Legal Provisions
+# Relating to IETF Documents (http://trustee.ietf.org/license-info).
 
 
-   """Simple format validator for self-published ipgeo feeds.
+"""Simple format validator for self-published ipgeo feeds.
 
-   This tool reads CSV data in the self-published ipgeo feed format from
-   the standard input and performs basic validation.  It is intended for
-   use by feed publishers before launching a feed.
-   """
+This tool reads CSV data in the self-published ipgeo feed format from
+the standard input and performs basic validation.  It is intended for
+use by feed publishers before launching a feed.
+"""
 
-   import csv
-   import ipaddr
-   import re
-   import sys
-
-
-   class IPGeoFeedValidator(object):
-     def __init__(self):
-       self.prefixes = {}
-       self.line_number = 0
-       self.output_log = {}
-       self.SetOutputStream(sys.stderr)
+import csv
+import ipaddr
+import re
+import sys
 
 
+class IPGeoFeedValidator(object):
+  def __init__(self):
+    self.prefixes = {}
+    self.line_number = 0
+    self.output_log = {}
+    self.SetOutputStream(sys.stderr)
+
+  def Validate(self, feed):
+    """Check validity of an IPGeo feed.
+
+    Args:
+      feed: iterable with feed lines
+    """
+
+    for line in feed:
+      self._ValidateLine(line)
+
+  def SetOutputStream(self, logfile):
 
 
-Kline, et al.           Expires January 29, 2015               [Page 16]
+
+Kline, et al.             Expires July 14, 2016                [Page 17]
 
-Internet-Draft         Self-published IP Geofeeds              July 2014
+Internet-Draft         Self-published IP Geofeeds           January 2016
 
 
-     def Validate(self, feed):
-       """Check validity of an IPGeo feed.
+    """Controls where the output messages go do (STDERR by default).
 
-       Args:
-         feed: iterable with feed lines
-       """
+    Use None to disable logging.
 
-       for line in feed:
-         self._ValidateLine(line)
+    Args:
+      logfile: a file object (e.g., sys.stdout or sys.stderr) or None.
+    """
+    self.output_stream = logfile
 
-     def SetOutputStream(self, logfile):
-       """Controls where the output messages go do (STDERR by default).
+  def CountErrors(self, severity):
+    """How many ERRORs or WARNINGs were generated."""
+    return len(self.output_log.get(severity, []))
 
-       Use None to disable logging.
+  ############################################################
+  def _ValidateLine(self, line):
+    line = line.rstrip('\r\n')
+    self.line_number += 1
+    self.line = line
+    self.is_correct_line = True
 
-       Args:
-         logfile: a file object (e.g., sys.stdout or sys.stderr) or None.
-       """
-       self.output_stream = logfile
+    if self._ShouldIgnoreLine(line):
+      return
 
-     def CountErrors(self, severity):
-       """How many ERRORs or WARNINGs were generated."""
-       return len(self.output_log.get(severity, []))
+    fields = [field for field in csv.reader([line])][0]
 
-     ############################################################
-     def _ValidateLine(self, line):
-       line = line.rstrip('\r\n')
-       self.line_number += 1
-       self.line = line
-       self.is_correct_line = True
+    self._ValidateFields(fields)
+    self._FlushOutputStream()
 
-       if self._ShouldIgnoreLine(line):
-         return
+  def _ShouldIgnoreLine(self, line):
+    line = line.strip()
+    return len(line) == 0 or line.startswith('#')
 
-       fields = [field for field in csv.reader([line])][0]
+  ############################################################
+  def _ValidateFields(self, fields):
+    assert(len(fields) > 0)
 
-       self._ValidateFields(fields)
-       self._FlushOutputStream()
+    is_correct = self._IsIPAddressOrPrefixCorrect(fields[0])
 
-     def _ShouldIgnoreLine(self, line):
-       line = line.strip()
-       return len(line) == 0 or line.startswith('#')
+    if len(fields) > 1:
+      if not self._IsCountryCode2Correct(fields[1]):
+        is_correct = False
 
-     ############################################################
-     def _ValidateFields(self, fields):
-       assert(len(fields) > 0)
+    if len(fields) > 2 and not self._IsRegionCodeCorrect(fields[2]):
+      is_correct = False
 
-       is_correct = self._IsIPAddressOrPrefixCorrect(fields[0])
+    if len(fields) != 5:
+      self._ReportWarning('5 fields were expected (got %d).'
+                          % len(fields))
 
 
 
-Kline, et al.           Expires January 29, 2015               [Page 17]
+Kline, et al.             Expires July 14, 2016                [Page 18]
 
-Internet-Draft         Self-published IP Geofeeds              July 2014
+Internet-Draft         Self-published IP Geofeeds           January 2016
 
 
-       if len(fields) > 1:
-         if not self._IsCountryCode2Correct(fields[1]):
-           is_correct = False
+  ############################################################
+  def _IsIPAddressOrPrefixCorrect(self, field):
+    if '/' in field:
+      return self._IsCIDRCorrect(field)
+    return self._IsIPAddressCorrect(field)
 
-       if len(fields) > 2 and not self._IsRegionCodeCorrect(fields[2]):
-         is_correct = False
+  def _IsCIDRCorrect(self, cidr):
+    try:
+      ipprefix = ipaddr.IPNetwork(cidr)
+      if ipprefix.network._ip != ipprefix._ip:
+        self._ReportError('Incorrect IP Network.')
+        return False
+      if ipprefix.is_private:
+        self._ReportError('IP Address must not be private.')
+        return False
+    except:
+      self._ReportError('Incorrect IP Network.')
+      return False
+    return True
 
-       if len(fields) != 5:
-         self._ReportWarning('5 fields were expected (got %d).'
-                             % len(fields))
+  def _IsIPAddressCorrect(self, ipaddress):
+    try:
+      ip = ipaddr.IPAddress(ipaddress)
+    except:
+      self._ReportError('Incorrect IP Address.')
+      return False
+    if ip.is_private:
+      self._ReportError('IP Address must not be private.')
+      return False
+    return True
 
-     ############################################################
-     def _IsIPAddressOrPrefixCorrect(self, field):
-       if '/' in field:
-         return self._IsCIDRCorrect(field)
-       return self._IsIPAddressCorrect(field)
+  ############################################################
+  def _IsCountryCode2Correct(self, country_code_2):
+    if len(country_code_2) == 0:
+      return True
+    if len(country_code_2) != 2 or not country_code_2.isalpha():
+      self._ReportError(
+          'Country code must be in the ISO 3166-1 alpha 2 format.')
+      return False
+    return True
 
-     def _IsCIDRCorrect(self, cidr):
-       try:
-         ipprefix = ipaddr.IPNetwork(cidr)
-         if ipprefix.network._ip != ipprefix._ip:
-           self._ReportError('Incorrect IP Network.')
-           return False
-         if ipprefix.is_private:
-           self._ReportError('IP Address must not be private.')
-           return False
-       except:
-         self._ReportError('Incorrect IP Network.')
-         return False
-       return True
-
-     def _IsIPAddressCorrect(self, ipaddress):
-       try:
-         ip = ipaddr.IPAddress(ipaddress)
-       except:
-         self._ReportError('Incorrect IP Address.')
-         return False
-       if ip.is_private:
-         self._ReportError('IP Address must not be private.')
-         return False
-       return True
-
-     ############################################################
-     def _IsCountryCode2Correct(self, country_code_2):
-       if len(country_code_2) == 0:
-         return True
-       if len(country_code_2) != 2 or not country_code_2.isalpha():
-         self._ReportError(
-
+  def _IsRegionCodeCorrect(self, region_code):
+    if len(region_code) == 0:
+      return True
+    if '-' not in region_code:
+      self._ReportError('Region code must be in the ISO 3166-2 format.')
+      return False
 
 
-Kline, et al.           Expires January 29, 2015               [Page 18]
+
+
+Kline, et al.             Expires July 14, 2016                [Page 19]
 
-Internet-Draft         Self-published IP Geofeeds              July 2014
+Internet-Draft         Self-published IP Geofeeds           January 2016
 
 
-             'Country code must be in the ISO 3166-1 alpha 2 format.')
-         return False
-       return True
+    parts = region_code.split('-')
+    if not self._IsCountryCode2Correct(parts[0]):
+      return False
+    return True
 
-     def _IsRegionCodeCorrect(self, region_code):
-       if len(region_code) == 0:
-         return True
-       if '-' not in region_code:
-         self._ReportError('Region code must be in the ISO 3166-2 format.')
-         return False
+  ############################################################
+  def _ReportError(self, message):
+    self._ReportWithSeverity('ERROR', message)
 
-       parts = region_code.split('-')
-       if not self._IsCountryCode2Correct(parts[0]):
-         return False
-       return True
+  def _ReportWarning(self, message):
+    self._ReportWithSeverity('WARNING', message)
 
-     ############################################################
-     def _ReportError(self, message):
-       self._ReportWithSeverity('ERROR', message)
+  def _ReportWithSeverity(self, severity, message):
+    self.is_correct_line = False
+    output_line = '%s: %s\n' % (severity, message)
 
-     def _ReportWarning(self, message):
-       self._ReportWithSeverity('WARNING', message)
+    if severity not in self.output_log:
+      self.output_log[severity] = []
+    self.output_log[severity].append(output_line)
 
-     def _ReportWithSeverity(self, severity, message):
-       self.is_correct_line = False
-       output_line = '%s: %s\n' % (severity, message)
+    if self.output_stream is not None:
+      self.output_stream.write(output_line)
 
-       if severity not in self.output_log:
-         self.output_log[severity] = []
-       self.output_log[severity].append(output_line)
+  def _FlushOutputStream(self):
+    if self.is_correct_line: return
+    if self.output_stream is None: return
 
-       if self.output_stream is not None:
-         self.output_stream.write(output_line)
-
-     def _FlushOutputStream(self):
-       if self.is_correct_line: return
-       if self.output_stream is None: return
-
-       self.output_stream.write('line %d: %s\n\n'
-                                % (self.line_number, self.line))
+    self.output_stream.write('line %d: %s\n\n'
+                             % (self.line_number, self.line))
 
 
-   ############################################################
-   def main():
-      feed_validator = IPGeoFeedValidator()
-      feed_validator.Validate(sys.stdin)
+############################################################
+def main():
+   feed_validator = IPGeoFeedValidator()
+   feed_validator.Validate(sys.stdin)
 
-      if feed_validator.CountErrors('ERROR'):
+   if feed_validator.CountErrors('ERROR'):
+     sys.exit(1)
 
-
-
-Kline, et al.           Expires January 29, 2015               [Page 19]
-
-Internet-Draft         Self-published IP Geofeeds              July 2014
-
-
-        sys.exit(1)
-
-   if __name__ == '__main__':
-     main()
+if __name__ == '__main__':
+  main()
 
    A unit test file, "ipgeo_feed_validator_test.py" is provided as well.
    It provides basic test coverage of the code above, though does not
    test correct handling of non-ASCII UTF-8 strings.
 
-   #!/usr/bin/python
-   #
-   # Copyright (c) 2012 IETF Trust and the persons identified as authors of
-   # the code.  All rights reserved.  Redistribution and use in source and
-   # binary forms, with or without modification, is permitted pursuant to,
-   # and subject to the license terms contained in, the Simplified BSD
-   # License set forth in Section 4.c of the IETF Trust's Legal Provisions
-   # Relating to IETF Documents (http://trustee.ietf.org/license-info).
-
-   import sys
-   from ipgeo_feed_validator import IPGeoFeedValidator
-
-   class IPGeoFeedValidatorTest(object):
-     def __init__(self):
-       self.validator = IPGeoFeedValidator()
-       self.validator.SetOutputStream(None)
-       self.successes = 0
-       self.failures = 0
-
-     def Run(self):
-       self.TestFeedLine('# asdf', 0, 0)
-       self.TestFeedLine('   ', 0, 0)
-       self.TestFeedLine('', 0, 0)
-
-       self.TestFeedLine('asdf', 1, 1)
-       self.TestFeedLine('asdf,US,,,', 1, 0)
-       self.TestFeedLine('aaaa::,US,,,', 0, 0)
-       self.TestFeedLine('zzzz::,US', 1, 1)
-       self.TestFeedLine(',US,,,', 1, 0)
-       self.TestFeedLine('55.66.77', 1, 1)
-       self.TestFeedLine('55.66.77.888', 1, 1)
-       self.TestFeedLine('55.66.77.asdf', 1, 1)
-
-       self.TestFeedLine('2001:db8:cafe::/48,PL,PL-MZ,,02-784', 0, 0)
-       self.TestFeedLine('2001:db8:cafe::/48', 0, 1)
-
-       self.TestFeedLine('55.66.77.88,PL', 0, 1)
-       self.TestFeedLine('55.66.77.88,PL,,,', 0, 0)
-       self.TestFeedLine('55.66.77.88,,,,', 0, 0)
+#!/usr/bin/python
+#
 
 
 
-Kline, et al.           Expires January 29, 2015               [Page 20]
+Kline, et al.             Expires July 14, 2016                [Page 20]
 
-Internet-Draft         Self-published IP Geofeeds              July 2014
+Internet-Draft         Self-published IP Geofeeds           January 2016
 
 
-       self.TestFeedLine('55.66.77.88,ZZ,,,', 0, 0)
-       self.TestFeedLine('55.66.77.88,US,,,', 0, 0)
-       self.TestFeedLine('55.66.77.88,USA,,,', 1, 0)
-       self.TestFeedLine('55.66.77.88,99,,,', 1, 0)
+# Copyright (c) 2012 IETF Trust and the persons identified as authors of
+# the code.  All rights reserved.  Redistribution and use in source and
+# binary forms, with or without modification, is permitted pursuant to,
+# and subject to the license terms contained in, the Simplified BSD
+# License set forth in Section 4.c of the IETF Trust's Legal Provisions
+# Relating to IETF Documents (http://trustee.ietf.org/license-info).
 
-       self.TestFeedLine('55.66.77.88,US,US-CA,,', 0, 0)
-       self.TestFeedLine('55.66.77.88,US,USA-CA,,', 1, 0)
-       self.TestFeedLine('55.66.77.88,USA,USA-CA,,', 2, 0)
+import sys
+from ipgeo_feed_validator import IPGeoFeedValidator
 
-       self.TestFeedLine('55.66.77.88,US,US-CA,Mountain View,', 0, 0)
-       self.TestFeedLine('55.66.77.88,US,US-CA,Mountain View,94043', 0, 0)
-       self.TestFeedLine('55.66.77.88,US,US-CA,Mountain View,94043,'
-                         '1600 Ampthitheatre Parkway', 0, 1)
+class IPGeoFeedValidatorTest(object):
+  def __init__(self):
+    self.validator = IPGeoFeedValidator()
+    self.validator.SetOutputStream(None)
+    self.successes = 0
+    self.failures = 0
 
-       self.TestFeedLine('55.66.77.0/24,US,,,', 0, 0)
-       self.TestFeedLine('55.66.77.88/24,US,,,', 1, 0)
-       self.TestFeedLine('55.66.77.88/32,US,,,', 0, 0)
-       self.TestFeedLine('55.66.77/24,US,,,', 1, 0)
-       self.TestFeedLine('55.66.77.0/35,US,,,', 1, 0)
+  def Run(self):
+    self.TestFeedLine('# asdf', 0, 0)
+    self.TestFeedLine('   ', 0, 0)
+    self.TestFeedLine('', 0, 0)
 
-       self.TestFeedLine('172.15.30.1,US,,,', 0, 0)
-       self.TestFeedLine('172.28.30.1,US,,,', 1, 0)
-       self.TestFeedLine('192.167.100.1,US,,,', 0, 0)
-       self.TestFeedLine('192.168.100.1,US,,,', 1, 0)
-       self.TestFeedLine('10.0.5.9,US,,,', 1, 0)
-       self.TestFeedLine('10.0.5.0/24,US,,,', 1, 0)
-       self.TestFeedLine('fc00::/48,PL,,,', 1, 0)
-       self.TestFeedLine('fe00::/48,PL,,,', 0, 0)
+    self.TestFeedLine('asdf', 1, 1)
+    self.TestFeedLine('asdf,US,,,', 1, 0)
+    self.TestFeedLine('aaaa::,US,,,', 0, 0)
+    self.TestFeedLine('zzzz::,US', 1, 1)
+    self.TestFeedLine(',US,,,', 1, 0)
+    self.TestFeedLine('55.66.77', 1, 1)
+    self.TestFeedLine('55.66.77.888', 1, 1)
+    self.TestFeedLine('55.66.77.asdf', 1, 1)
 
-       print '%d tests passed, %d failed' % (self.successes, self.failures)
+    self.TestFeedLine('2001:db8:cafe::/48,PL,PL-MZ,,02-784', 0, 0)
+    self.TestFeedLine('2001:db8:cafe::/48', 0, 1)
 
-     def IsOutputLogCorrectAtSeverity(self, severity, expected_msg_count):
-       msg_count = self.validator.CountErrors(severity)
+    self.TestFeedLine('55.66.77.88,PL', 0, 1)
+    self.TestFeedLine('55.66.77.88,PL,,,', 0, 0)
+    self.TestFeedLine('55.66.77.88,,,,', 0, 0)
+    self.TestFeedLine('55.66.77.88,ZZ,,,', 0, 0)
+    self.TestFeedLine('55.66.77.88,US,,,', 0, 0)
+    self.TestFeedLine('55.66.77.88,USA,,,', 1, 0)
+    self.TestFeedLine('55.66.77.88,99,,,', 1, 0)
 
-       if msg_count != expected_msg_count:
-         print 'TEST FAILED: %s\nexpected %d %s[s], observed %d\n%s\n' % (
-             self.validator.line, expected_sg_count, severity, msg_count,
-             str(self.validator.output_log[severity]))
-         return False
-       return True
+    self.TestFeedLine('55.66.77.88,US,US-CA,,', 0, 0)
+    self.TestFeedLine('55.66.77.88,US,USA-CA,,', 1, 0)
+    self.TestFeedLine('55.66.77.88,USA,USA-CA,,', 2, 0)
 
-     def IsOutputLogCorrect(self, new_errors, new_warnings):
-       retval = True
-
-       if not self.IsOutputLogCorrectAtSeverity('ERROR', new_errors):
-         retval = False
-       if not self.IsOutputLogCorrectAtSeverity('WARNING', new_warnings):
-         retval = False
+    self.TestFeedLine('55.66.77.88,US,US-CA,Mountain View,', 0, 0)
+    self.TestFeedLine('55.66.77.88,US,US-CA,Mountain View,94043', 0, 0)
 
 
 
-Kline, et al.           Expires January 29, 2015               [Page 21]
+Kline, et al.             Expires July 14, 2016                [Page 21]
 
-Internet-Draft         Self-published IP Geofeeds              July 2014
+Internet-Draft         Self-published IP Geofeeds           January 2016
 
 
-       return retval
+    self.TestFeedLine('55.66.77.88,US,US-CA,Mountain View,94043,'
+                      '1600 Ampthitheatre Parkway', 0, 1)
 
-     def TestFeedLine(self, line, warning_count, error_count):
-       self.validator.output_log['WARNING'] = []
-       self.validator.output_log['ERROR'] = []
-       self.validator._ValidateLine(line)
+    self.TestFeedLine('55.66.77.0/24,US,,,', 0, 0)
+    self.TestFeedLine('55.66.77.88/24,US,,,', 1, 0)
+    self.TestFeedLine('55.66.77.88/32,US,,,', 0, 0)
+    self.TestFeedLine('55.66.77/24,US,,,', 1, 0)
+    self.TestFeedLine('55.66.77.0/35,US,,,', 1, 0)
 
-       if not self.IsOutputLogCorrect(warning_count, error_count):
-         self.failures += 1
-         return False
+    self.TestFeedLine('172.15.30.1,US,,,', 0, 0)
+    self.TestFeedLine('172.28.30.1,US,,,', 1, 0)
+    self.TestFeedLine('192.167.100.1,US,,,', 0, 0)
+    self.TestFeedLine('192.168.100.1,US,,,', 1, 0)
+    self.TestFeedLine('10.0.5.9,US,,,', 1, 0)
+    self.TestFeedLine('10.0.5.0/24,US,,,', 1, 0)
+    self.TestFeedLine('fc00::/48,PL,,,', 1, 0)
+    self.TestFeedLine('fe00::/48,PL,,,', 0, 0)
 
-       self.successes += 1
-       return True
+    print '%d tests passed, %d failed' % (self.successes, self.failures)
+
+  def IsOutputLogCorrectAtSeverity(self, severity, expected_msg_count):
+    msg_count = self.validator.CountErrors(severity)
+
+    if msg_count != expected_msg_count:
+      print 'TEST FAILED: %s\nexpected %d %s[s], observed %d\n%s\n' % (
+          self.validator.line, expected_msg_count, severity, msg_count,
+          str(self.validator.output_log[severity]))
+      return False
+    return True
+
+  def IsOutputLogCorrect(self, new_errors, new_warnings):
+    retval = True
+
+    if not self.IsOutputLogCorrectAtSeverity('ERROR', new_errors):
+      retval = False
+    if not self.IsOutputLogCorrectAtSeverity('WARNING', new_warnings):
+      retval = False
+
+    return retval
+
+  def TestFeedLine(self, line, warning_count, error_count):
+    self.validator.output_log['WARNING'] = []
+    self.validator.output_log['ERROR'] = []
+    self.validator._ValidateLine(line)
+
+    if not self.IsOutputLogCorrect(warning_count, error_count):
+      self.failures += 1
+      return False
 
 
-   if __name__ == '__main__':
-     IPGeoFeedValidatorTest().Run()
+
+Kline, et al.             Expires July 14, 2016                [Page 22]
+
+Internet-Draft         Self-published IP Geofeeds           January 2016
+
+
+    self.successes += 1
+    return True
+
+
+if __name__ == '__main__':
+  IPGeoFeedValidatorTest().Run()
 
 Authors' Addresses
 
@@ -1229,4 +1274,15 @@ Authors' Addresses
 
 
 
-Kline, et al.           Expires January 29, 2015               [Page 22]
+
+
+
+
+
+
+
+
+
+
+
+Kline, et al.             Expires July 14, 2016                [Page 23]

--- a/draft.xml
+++ b/draft.xml
@@ -1215,7 +1215,7 @@ class IPGeoFeedValidatorTest(object):
 
     if msg_count != expected_msg_count:
       print 'TEST FAILED: %s\nexpected %d %s[s], observed %d\n%s\n' % (
-          self.validator.line, expected_sg_count, severity, msg_count,
+          self.validator.line, expected_msg_count, severity, msg_count,
           str(self.validator.output_log[severity]))
       return False
     return True


### PR DESCRIPTION
I fixed a typo in the example code & update the draft.txt using xml2rfc.